### PR TITLE
Reorganize key names

### DIFF
--- a/js/forum/src/addSubscriptionBadge.js
+++ b/js/forum/src/addSubscriptionBadge.js
@@ -9,7 +9,7 @@ export default function addSubscriptionBadge() {
     switch (this.subscription()) {
       case 'follow':
         badge = Badge.component({
-          label: app.translator.trans('flarum-subscriptions.forum.following'),
+          label: app.translator.trans('flarum-subscriptions.forum.badge.following_tooltip'),
           icon: 'star',
           type: 'following'
         });
@@ -17,7 +17,7 @@ export default function addSubscriptionBadge() {
 
       case 'ignore':
         badge = Badge.component({
-          label: app.translator.trans('flarum-subscriptions.forum.ignoring'),
+          label: app.translator.trans('flarum-subscriptions.forum.badge.ignoring_tooltip'),
           icon: 'eye-slash',
           type: 'ignoring'
         });

--- a/js/forum/src/addSubscriptionControls.js
+++ b/js/forum/src/addSubscriptionControls.js
@@ -9,9 +9,9 @@ export default function addSubscriptionControls() {
   extend(DiscussionControls, 'userControls', function(items, discussion, context) {
     if (app.session.user && !(context instanceof DiscussionPage)) {
       const states = {
-        none: {label: app.translator.trans('flarum-subscriptions.forum.follow'), icon: 'star', save: 'follow'},
-        follow: {label: app.translator.trans('flarum-subscriptions.forum.unfollow'), icon: 'star-o', save: false},
-        ignore: {label: app.translator.trans('flarum-subscriptions.forum.unignore'), icon: 'eye', save: false}
+        none: {label: app.translator.trans('flarum-subscriptions.forum.discussion_controls.follow_button'), icon: 'star', save: 'follow'},
+        follow: {label: app.translator.trans('flarum-subscriptions.forum.discussion_controls.unfollow_button'), icon: 'star-o', save: false},
+        ignore: {label: app.translator.trans('flarum-subscriptions.forum.discussion_controls.unignore_button'), icon: 'eye', save: false}
       };
 
       const subscription = discussion.subscription() || 'none';

--- a/js/forum/src/addSubscriptionFilter.js
+++ b/js/forum/src/addSubscriptionFilter.js
@@ -12,7 +12,7 @@ export default function addSubscriptionFilter() {
 
       items.add('following', LinkButton.component({
         href: app.route('index.filter', params),
-        children: app.translator.trans('flarum-subscriptions.forum.following'),
+        children: app.translator.trans('flarum-subscriptions.forum.index.following_link'),
         icon: 'star'
       }), 50);
     }

--- a/js/forum/src/components/NewPostNotification.js
+++ b/js/forum/src/components/NewPostNotification.js
@@ -15,6 +15,6 @@ export default class NewPostNotification extends Notification {
   }
 
   content() {
-    return app.translator.trans('flarum-subscriptions.forum.new_post_notification', {user: this.props.notification.sender()});
+    return app.translator.trans('flarum-subscriptions.forum.notifications:new_post_text', {user: this.props.notification.sender()});
   }
 }

--- a/js/forum/src/components/SubscriptionMenu.js
+++ b/js/forum/src/components/SubscriptionMenu.js
@@ -9,18 +9,18 @@ export default class SubscriptionMenu extends Component {
     const discussion = this.props.discussion;
     const subscription = discussion.subscription();
 
-    let buttonLabel = app.translator.trans('flarum-subscriptions.forum.follow');
+    let buttonLabel = app.translator.trans('flarum-subscriptions.forum.sub_controls.follow_button');
     let buttonIcon = 'star-o';
     const buttonClass = 'SubscriptionMenu-button--' + subscription;
 
     switch (subscription) {
       case 'follow':
-        buttonLabel = app.translator.trans('flarum-subscriptions.forum.following');
+        buttonLabel = app.translator.trans('flarum-subscriptions.forum.sub_controls.following_button');
         buttonIcon = 'star';
         break;
 
       case 'ignore':
-        buttonLabel = app.translator.trans('flarum-subscriptions.forum.ignoring');
+        buttonLabel = app.translator.trans('flarum-subscriptions.forum.sub_controls.ignoring_button');
         buttonIcon = 'eye-slash';
         break;
 
@@ -32,20 +32,20 @@ export default class SubscriptionMenu extends Component {
       {
         subscription: false,
         icon: 'star-o',
-        label: app.translator.trans('flarum-subscriptions.forum.not_following'),
-        description: app.translator.trans('flarum-subscriptions.forum.not_following_description')
+        label: app.translator.trans('flarum-subscriptions.forum.sub_controls.not_following_button'),
+        description: app.translator.trans('flarum-subscriptions.forum.sub_controls.not_following_text')
       },
       {
         subscription: 'follow',
         icon: 'star',
-        label: app.translator.trans('flarum-subscriptions.forum.following'),
-        description: app.translator.trans('flarum-subscriptions.forum.following_description')
+        label: app.translator.trans('flarum-subscriptions.forum.sub_controls.following_button'),
+        description: app.translator.trans('flarum-subscriptions.forum.sub_controls.following_text')
       },
       {
         subscription: 'ignore',
         icon: 'eye-slash',
-        label: app.translator.trans('flarum-subscriptions.forum.ignoring'),
-        description: app.translator.trans('flarum-subscriptions.forum.ignoring_description')
+        label: app.translator.trans('flarum-subscriptions.forum.sub_controls.ignoring_button'),
+        description: app.translator.trans('flarum-subscriptions.forum.sub_controls.ignoring_text')
       }
     ];
 

--- a/js/forum/src/main.js
+++ b/js/forum/src/main.js
@@ -22,7 +22,7 @@ app.initializers.add('subscriptions', function() {
     items.add('newPost', {
       name: 'newPost',
       icon: 'star',
-      label: app.translator.trans('flarum-subscriptions.forum.notify_new_post')
+      label: app.translator.trans('flarum-subscriptions.forum.settings.notify_new_post_label')
     });
   });
 });


### PR DESCRIPTION
See [flarum/core #265](https://github.com/flarum/core/issues/265).
- Adjusts key names to three-tier namespacing.
- Extracts previously unextracted strings.
