### PR TITLE
Queue 'new post' notification

### DIFF
--- a/src/Job/SendReplyNotification.php
+++ b/src/Job/SendReplyNotification.php
@@ -1,8 +1,15 @@
 <?php
 
+/*
+ * This file is part of Flarum.
+ *
+ * (c) Toby Zerner <toby.zerner@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
 
 namespace Flarum\Subscriptions\Job;
-
 
 use Flarum\Notification\NotificationSyncer;
 use Flarum\Post\Post;
@@ -35,7 +42,8 @@ class SendReplyNotification implements ShouldQueue
         $this->lastPostNumber = $lastPostNumber;
     }
 
-    public function handle(NotificationSyncer $notifications) {
+    public function handle(NotificationSyncer $notifications)
+    {
         $post = $this->post;
         $discussion = $post->discussion;
 

--- a/src/Listener/SendNotificationWhenReplyIsPosted.php
+++ b/src/Listener/SendNotificationWhenReplyIsPosted.php
@@ -11,39 +11,26 @@
 
 namespace Flarum\Subscriptions\Listener;
 
-use Flarum\Notification\NotificationSyncer;
 use Flarum\Post\Event\Posted;
-use Flarum\Subscriptions\Notification\NewPostBlueprint;
+use Flarum\Subscriptions\Job\SendReplyNotification;
+use Illuminate\Contracts\Queue\Queue;
 
 class SendNotificationWhenReplyIsPosted
 {
     /**
-     * @var NotificationSyncer
+     * @var Queue
      */
-    protected $notifications;
+    protected $queue;
 
-    /**
-     * @param NotificationSyncer $notifications
-     */
-    public function __construct(NotificationSyncer $notifications)
+    public function __construct(Queue $queue)
     {
-        $this->notifications = $notifications;
+        $this->queue = $queue;
     }
 
     public function handle(Posted $event)
     {
-        $post = $event->post;
-        $discussion = $post->discussion;
-
-        $notify = $discussion->readers()
-            ->where('users.id', '!=', $post->user_id)
-            ->where('discussion_user.subscription', 'follow')
-            ->where('discussion_user.last_read_post_number', $discussion->last_post_number)
-            ->get();
-
-        $this->notifications->sync(
-            new NewPostBlueprint($event->post),
-            $notify->all()
+        $this->queue->push(
+            new SendReplyNotification($event->post, $event->post->discussion->last_post_number)
         );
     }
 }


### PR DESCRIPTION
**Fixes flarum/core#1869**

The last post number needs to be passed because if using a queue driver other than `sync`, the discussion's details are updated (or another post could have been added) so it will target the current or later posts. This results in no user ever having read the latest post in the discussion and not qualifying for a notification. Probably wouldn't be needed if we don't serialize the models (i.e. assign post ID to job, get from DB when job runs)... I assume we want to?