### PR TITLE
Replaced whereExists/whereNotExists with whereIn/whereNotIn

### DIFF
--- a/src/Gambit/SubscriptionGambit.php
+++ b/src/Gambit/SubscriptionGambit.php
@@ -26,14 +26,12 @@ class SubscriptionGambit extends AbstractRegexGambit
     {
         $actor = $search->getActor();
 
-        // might be better as `id IN (subquery)`?
-        $method = $negate ? 'whereNotExists' : 'whereExists';
-        $search->getQuery()->$method(function ($query) use ($actor, $matches) {
-            $query->selectRaw('1')
-                  ->from('discussion_user')
-                  ->whereColumn('discussions.id', 'discussion_id')
-                  ->where('user_id', $actor->id)
-                  ->where('subscription', $matches[1] === 'follow' ? 'follow' : 'ignore');
+        $method = $negate ? 'whereNotIn' : 'whereIn';
+        $search->getQuery()->$method('id', function ($query) use ($actor, $matches) {
+            $query->selectRaw('discussion_id')
+                ->from('discussion_user')
+                ->where('user_id', $actor->id)
+                ->where('subscription', $matches[1] === 'follow' ? 'follow' : 'ignore');
         });
     }
 }

--- a/src/Gambit/SubscriptionGambit.php
+++ b/src/Gambit/SubscriptionGambit.php
@@ -28,7 +28,7 @@ class SubscriptionGambit extends AbstractRegexGambit
 
         $method = $negate ? 'whereNotIn' : 'whereIn';
         $search->getQuery()->$method('id', function ($query) use ($actor, $matches) {
-            $query->selectRaw('discussion_id')
+            $query->select('discussion_id')
                 ->from('discussion_user')
                 ->where('user_id', $actor->id)
                 ->where('subscription', $matches[1] === 'follow' ? 'follow' : 'ignore');


### PR DESCRIPTION
At giffgaff we were seeing the main search gambit take up to 16 seconds when selecting 'following' after logging in.

Replacing the query with an 'IN' statement turned this from 16 seconds into 0.396 seconds!



