### PR TITLE
Add missing SplitDropdown classes

### DIFF
--- a/js/src/forum/components/SubscriptionMenu.js
+++ b/js/src/forum/components/SubscriptionMenu.js
@@ -60,7 +60,7 @@ export default class SubscriptionMenu extends Dropdown {
       : 'flarum-subscriptions.forum.sub_controls.notify_alert_tooltip'));
 
     const buttonProps = {
-      className: 'Button SubscriptionMenu-button ' + buttonClass,
+      className: 'SplitDropdown-button Button SubscriptionMenu-button ' + buttonClass,
       icon: buttonIcon,
       children: buttonLabel,
       onclick: this.saveSubscription.bind(this, discussion, ['follow', 'ignore'].indexOf(subscription) !== -1 ? false : 'follow'),
@@ -81,11 +81,11 @@ export default class SubscriptionMenu extends Dropdown {
     }
 
     return (
-      <div className="Dropdown ButtonGroup SubscriptionMenu">
+      <div className="Dropdown dropdown Dropdown--split ButtonGroup SubscriptionMenu">
         {Button.component(buttonProps)}
 
         <button className={'Dropdown-toggle Button Button--icon ' + buttonClass} data-toggle="dropdown">
-          {icon('fas fa-caret-down', {className: 'Button-icon'})}
+          {icon('fas fa-caret-down', {className: 'Button-caret'})}
         </button>
 
         <ul className="Dropdown-menu dropdown-menu Dropdown-menu--right">

--- a/less/forum.less
+++ b/less/forum.less
@@ -15,6 +15,14 @@
 }
 .SubscriptionMenu .Dropdown-menu {
   min-width: 260px;
+
+  @media @tablet-up {
+    & li:first-child {
+      &, + li.Dropdown-separator {
+        display: block;
+      }
+    }
+  }
 }
 .SubscriptionMenuItem-label {
   padding-left: 25px;

--- a/less/forum.less
+++ b/less/forum.less
@@ -17,7 +17,7 @@
   min-width: 260px;
 
   @media @tablet-up {
-    & li:first-child {
+    li:first-child {
       &, + li.Dropdown-separator {
         display: block;
       }


### PR DESCRIPTION
Fixes https://github.com/flarum/core/issues/2114

I couldn't use the whole `SplitDropdown` component instead of the `Dropdown` because the **definition** is clear:

https://github.com/flarum/core/blob/89ef14faf13e4d661ee9f4f636a32578c73bf760/js/src/common/components/SplitDropdown.js#L5-L8

We have three children in `SubscriptionMenu` button but we don't want to show the first child (that would be "Not Following") or other children as a button.

So what I'm understanding here is we want its look but not its functionality.