### PR TITLE
change value of subscribed from false to null in the JSON API

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -40,7 +40,7 @@ return [
     (new Extend\ApiSerializer(DiscussionSerializer::class))
         ->attribute('subscription', function (DiscussionSerializer $serializer, Discussion $discussion) {
             if ($state = $discussion->state) {
-                return $state->subscription ?: false;
+                return $state->subscription;
             }
         }),
 

--- a/js/src/forum/addSubscriptionControls.js
+++ b/js/src/forum/addSubscriptionControls.js
@@ -10,8 +10,8 @@ export default function addSubscriptionControls() {
     if (app.session.user && !(context instanceof DiscussionPage)) {
       const states = {
         none: {label: app.translator.trans('flarum-subscriptions.forum.discussion_controls.follow_button'), icon: 'fas fa-star', save: 'follow'},
-        follow: {label: app.translator.trans('flarum-subscriptions.forum.discussion_controls.unfollow_button'), icon: 'far fa-star', save: false},
-        ignore: {label: app.translator.trans('flarum-subscriptions.forum.discussion_controls.unignore_button'), icon: 'fas fa-eye', save: false}
+        follow: {label: app.translator.trans('flarum-subscriptions.forum.discussion_controls.unfollow_button'), icon: 'far fa-star', save: null},
+        ignore: {label: app.translator.trans('flarum-subscriptions.forum.discussion_controls.unignore_button'), icon: 'fas fa-eye', save: null}
       };
 
       const subscription = discussion.subscription() || 'none';

--- a/js/src/forum/components/SubscriptionMenu.js
+++ b/js/src/forum/components/SubscriptionMenu.js
@@ -11,7 +11,7 @@ export default class SubscriptionMenu extends Dropdown {
 
     this.options = [
       {
-        subscription: false,
+        subscription: null,
         icon: 'far fa-star',
         label: app.translator.trans('flarum-subscriptions.forum.sub_controls.not_following_button'),
         description: app.translator.trans('flarum-subscriptions.forum.sub_controls.not_following_text')
@@ -64,11 +64,11 @@ export default class SubscriptionMenu extends Dropdown {
     const buttonAttrs = {
       className: 'Button SubscriptionMenu-button ' + buttonClass,
       icon: buttonIcon,
-      onclick: this.saveSubscription.bind(this, discussion, ['follow', 'ignore'].indexOf(subscription) !== -1 ? false : 'follow'),
+      onclick: this.saveSubscription.bind(this, discussion, ['follow', 'ignore'].indexOf(subscription) !== -1 ? null : 'follow'),
       title: title
     };
 
-    if ((notifyEmail || notifyAlert) && subscription === false) {
+    if ((notifyEmail || notifyAlert) && subscription === null) {
       buttonAttrs.oncreate = buttonAttrs.onupdate = vnode => {
         $(vnode.dom).tooltip({
           container: '.SubscriptionMenu',

--- a/src/Listener/SaveSubscriptionToDatabase.php
+++ b/src/Listener/SaveSubscriptionToDatabase.php
@@ -18,7 +18,7 @@ class SaveSubscriptionToDatabase
         $discussion = $event->discussion;
         $data = $event->data;
 
-        if (isset($data['attributes']['subscription'])) {
+        if (array_key_exists('subscription', $data['attributes'])) {
             $actor = $event->actor;
             $subscription = $data['attributes']['subscription'];
 


### PR DESCRIPTION
Hi! This is in regards to [#1871](https://github.com/flarum/core/issues/1871). It is similar to [https://github.com/flarum/subscriptions/pull/25](https://github.com/flarum/subscriptions/pull/25), but with no null check in src/Listener/AddDiscussionSubscriptionAttribute.php. Also, I used `array_key_exists()` instead of `isset()` in src/Listener/SaveSubscriptionToDatabase.php because the value of the `subscription` key should be allowed to be null.