### PR TITLE
Apply `is:following` q param to GlobalSearchState

### DIFF
--- a/js/src/forum/addSubscriptionFilter.js
+++ b/js/src/forum/addSubscriptionFilter.js
@@ -1,7 +1,7 @@
 import { extend } from 'flarum/extend';
 import LinkButton from 'flarum/components/LinkButton';
 import IndexPage from 'flarum/components/IndexPage';
-import DiscussionListState from 'flarum/states/DiscussionListState';
+import GlobalSearchState from 'flarum/states/GlobalSearchState';
 
 export default function addSubscriptionFilter() {
   extend(IndexPage.prototype, 'navItems', function(items) {
@@ -21,9 +21,9 @@ export default function addSubscriptionFilter() {
     }
   });
 
-  extend(DiscussionListState.prototype, 'requestParams', function(params) {
+  extend(GlobalSearchState.prototype, 'params', function(params) {
     if (app.current.get('routeName') === 'following') {
-      params.filter.q = (params.filter.q || '') + ' is:following';
+      params.q = (params.q || '') + ' is:following';
     }
   });
 }

--- a/js/src/forum/addSubscriptionFilter.js
+++ b/js/src/forum/addSubscriptionFilter.js
@@ -1,6 +1,7 @@
 import { extend } from 'flarum/extend';
 import LinkButton from 'flarum/components/LinkButton';
 import IndexPage from 'flarum/components/IndexPage';
+import DiscussionListState from 'flarum/states/DiscussionListState';
 import GlobalSearchState from 'flarum/states/GlobalSearchState';
 
 export default function addSubscriptionFilter() {
@@ -21,9 +22,15 @@ export default function addSubscriptionFilter() {
     }
   });
 
-  extend(GlobalSearchState.prototype, 'params', function(params) {
-    if (app.current.get('routeName') === 'following') {
-      params.q = (params.q || '') + ' is:following';
+  extend(GlobalSearchState.prototype, 'params', function (params) {
+    // We can't set `q` here directly, as that would make the search bar
+    // think that text has been entered, and display the "clear" button.
+    params.onFollowing = app.current.get('routeName') === 'following';
+  });
+
+  extend(DiscussionListState.prototype, 'requestParams', function (params) {
+    if (this.params.onFollowing) {
+      params.filter.q = (params.filter.q || '') + ' is:following';
     }
   });
 }


### PR DESCRIPTION
Fixes https://github.com/flarum/core/issues/2516

This ensures that it will be taken into account by IndexPage's `refreshParams` call, preventing the following page from being shown if the user:

1. goes to following
2. goes to any other page not inheriting IndexPage
3. goes to 'all discussions'

Ref https://github.com/flarum/core/issues/2516 for a full explanation.